### PR TITLE
fix: replace broken /docs/env/agent-policy link with env overview

### DIFF
--- a/docs/root/user-manual/policy-enforcement-configuration.md
+++ b/docs/root/user-manual/policy-enforcement-configuration.md
@@ -354,7 +354,7 @@ No action required for existing deployments. The new mode defaults to `offering`
 - [Managing Restrictions](managing-restrictions.md) - Device-level restriction management
 - [Policies & Restrictions Overview](policies-restrictions-overview.md) - Understanding the rule system
 - [Rule Fields & Expressions](rule-fields-expressions.md) - Advanced rule configuration
-- [Agent Policy Configuration (Environment Variables)](/docs/env/agent-policy) - Technical reference
+- [Environment Variables Overview](/docs/env/) - Technical reference
 - [FAQ: Policy Enforcement](/docs/root/FAQ#policy-enforcement) - Common questions
 
 ## Need Help?


### PR DESCRIPTION
This pull request updates the documentation to improve clarity around environment variable references for policy enforcement configuration.

Documentation improvements:

* Updated the sidebar link in `policy-enforcement-configuration.md` from "Agent Policy Configuration (Environment Variables)" to the broader "Environment Variables Overview" page, providing users with a more general technical reference.
